### PR TITLE
Version Bump: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- **Android**: Reference `currentActivity` in `exitApp` method to prevent crashes when exiting the app. ([#5](https://github.com/logicwind/react-native-exit-app/pull/5))
+
 ## 0.1.0
 
 - Initial release of `react-native-exit-app`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicwind/react-native-exit-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Exit / Close / Kill / shutdown your react native app. Does not invoke a crash notification.",
   "source": "./src/index.tsx",
   "main": "./lib/module/index.js",


### PR DESCRIPTION
What's new
- **Android**: Reference `currentActivity` in `exitApp` method to prevent crashes when exiting the app. ([#5](https://github.com/logicwind/react-native-exit-app/pull/5))